### PR TITLE
JWT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
             <artifactId>spring-boot-starter-mail</artifactId>
             <version>2.5.6</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/adasoft/tis/core/utils/JWTProvider.java
+++ b/src/main/java/com/adasoft/tis/core/utils/JWTProvider.java
@@ -1,0 +1,51 @@
+package com.adasoft.tis.core.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
+import java.security.Key;
+
+/**
+ * Proveedor para la creación de tokens y desencriptación de ID de usuarios con JWT.
+ */
+@Component
+public class JWTProvider {
+    @Value("${jwt.secret}")
+    private String secret;
+
+    /**
+     * Crear token de acuerdo al ID de un usuario.
+     *
+     * @param userId ID del usuario que se va a encriptar en el token.
+     * @return el token creado.
+     */
+    public String create(final Long userId) {
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+        byte[] apiKeySecretBytes = DatatypeConverter.parseBase64Binary(secret);
+        Key signingKey = new SecretKeySpec(apiKeySecretBytes, signatureAlgorithm.getJcaName());
+
+        JwtBuilder builder = Jwts.builder().setId(String.valueOf(userId)).signWith(signatureAlgorithm, signingKey);
+
+        return builder.compact();
+    }
+
+    /**
+     * Desencriptar el ID del usuario de acuerdo a un token.
+     *
+     * @param token del que se va a desencriptar el ID del usuario
+     * @return el ID del usuario desencriptado.
+     */
+    public Long decryptUserId(final String token) {
+        byte[] apiKeySecretBytes = DatatypeConverter.parseBase64Binary(secret);
+        Claims claims = Jwts.parser().setSigningKey(apiKeySecretBytes).parseClaimsJws(token).getBody();
+
+        return Long.valueOf(claims.getId());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,5 @@ spring.mail.username=${EMAIL_ADDRESS}
 spring.mail.password=${EMAIL_APP_PW}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+# Configuracion de JWT
+jwt.secret=${JWT_SECRET}

--- a/src/test/java/com/adasoft/tis/core/utils/JWTProviderTest.java
+++ b/src/test/java/com/adasoft/tis/core/utils/JWTProviderTest.java
@@ -1,0 +1,40 @@
+package com.adasoft.tis.core.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@SpringBootTest(classes = JWTProvider.class)
+class JWTProviderTest {
+    @Autowired
+    private JWTProvider jwtProvider;
+
+    private static final Long USER_ID = 860104577966742482L;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        token = jwtProvider.create(USER_ID);
+    }
+
+    @Test
+    void createToken() {
+        assertNotEquals(token, null);
+    }
+
+    @Test
+    void tokenNotEmpty() {
+        assertNotEquals(token, "");
+    }
+
+    @Test
+    void getUserId() {
+        Long decryptedUserId = jwtProvider.decryptUserId(token);
+        assertEquals(decryptedUserId, USER_ID);
+    }
+}


### PR DESCRIPTION
Se creó JWTProvider para crear tokens para los usuarios.
- Se crea token de acuerdo al ID del usuario.
- Se puede desencriptar el ID del usuario dado un token.
- Se realizó sus pruebas unitarias necesarias.
> **Nota:** Se debe agregar una nueva variable de entorno `JWT_SECRET`