### PR TITLE
EndPoint Historial de Publicaciones

### DIFF
--- a/src/main/java/com/adasoft/tis/controllers/AdviserRestController.java
+++ b/src/main/java/com/adasoft/tis/controllers/AdviserRestController.java
@@ -6,6 +6,7 @@ import com.adasoft.tis.dto.adviser.AdviserResponseDTO;
 import com.adasoft.tis.dto.adviser.CreateAdviserDTO;
 import com.adasoft.tis.dto.adviser.UpdateAdviserDTO;
 import com.adasoft.tis.dto.classCode.ClassCodeResponseDTO;
+import com.adasoft.tis.dto.publication.PublicationResponseDTO;
 import com.adasoft.tis.dto.space.SpaceCompactResponseDTO;
 import com.adasoft.tis.dto.spaceAnswer.SpaceAnswerResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +21,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
 import java.util.Collection;
+
+import static com.adasoft.tis.domain.Publication.PublicationType;
 
 @Tag(name = "AdviserRestController", description = "Controlador para gestionar Advisers")
 public interface AdviserRestController {
@@ -305,5 +308,41 @@ public interface AdviserRestController {
         Long userId,
         @Parameter(description = "ID del adviser") Long adviserId,
         @Parameter(description = "Tipo de space") Space.SpaceType spaceType
+    );
+
+    @Operation(summary = "Obtener el historial de Publicaciones del adviser", responses = {
+        @ApiResponse(
+            description = "Historial de Publicaciones obtenidos satisfactoriamente",
+            responseCode = "200",
+            content = @Content(
+                mediaType = "application/json",
+                array = @ArraySchema(schema = @Schema(implementation = PublicationResponseDTO.class))
+            )
+        ),
+        @ApiResponse(
+            description = "No autorizado, el token es inválido",
+            responseCode = "401",
+            content = @Content(
+                mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            description = "No existe el Asesor",
+            responseCode = "404",
+            content = @Content(
+                mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    }, parameters = @Parameter(
+        in = ParameterIn.HEADER,
+        name = "X-Token",
+        description = "Token del usuario",
+        schema = @Schema(implementation = String.class),
+        required = true
+    ))
+    ResponseEntity<Collection<SpaceCompactResponseDTO>> getPublicationsHistory(
+        Long userId,
+        @Parameter(description = "ID del Asesor") Long id,
+        @Parameter(description = "Tipo de publicación") PublicationType publicationType
     );
 }

--- a/src/main/java/com/adasoft/tis/controllers/AdviserRestController.java
+++ b/src/main/java/com/adasoft/tis/controllers/AdviserRestController.java
@@ -340,7 +340,7 @@ public interface AdviserRestController {
         schema = @Schema(implementation = String.class),
         required = true
     ))
-    ResponseEntity<Collection<SpaceCompactResponseDTO>> getPublicationsHistory(
+    ResponseEntity<Collection<PublicationResponseDTO>> getPublicationsHistory(
         Long userId,
         @Parameter(description = "ID del Asesor") Long id,
         @Parameter(description = "Tipo de publicación") PublicationType publicationType

--- a/src/main/java/com/adasoft/tis/controllers/impl/AdviserRestControllerImpl.java
+++ b/src/main/java/com/adasoft/tis/controllers/impl/AdviserRestControllerImpl.java
@@ -1,6 +1,7 @@
 package com.adasoft.tis.controllers.impl;
 
 import com.adasoft.tis.controllers.AdviserRestController;
+import com.adasoft.tis.domain.Publication;
 import com.adasoft.tis.domain.Space;
 import com.adasoft.tis.dto.adviser.AdviserResponseDTO;
 import com.adasoft.tis.dto.adviser.CreateAdviserDTO;
@@ -110,5 +111,14 @@ public class AdviserRestControllerImpl implements AdviserRestController {
         Collection<SpaceCompactResponseDTO> responses = spaceService.getAdviserSpaces(adviserId, spaceType);
         return ResponseEntity.ok(responses);
 
+    }
+
+    @GetMapping("/{adviserId}/publications/history")
+    @Override
+    public ResponseEntity<Collection<SpaceCompactResponseDTO>> getPublicationsHistory(
+        @RequestAttribute("userId") final Long userId,
+        @NotNull @PathVariable("adviserId") final Long adviserId,
+        @NotNull @RequestParam("type") final Publication.PublicationType publicationType) {
+        return null;
     }
 }

--- a/src/main/java/com/adasoft/tis/controllers/impl/AdviserRestControllerImpl.java
+++ b/src/main/java/com/adasoft/tis/controllers/impl/AdviserRestControllerImpl.java
@@ -7,12 +7,10 @@ import com.adasoft.tis.dto.adviser.AdviserResponseDTO;
 import com.adasoft.tis.dto.adviser.CreateAdviserDTO;
 import com.adasoft.tis.dto.adviser.UpdateAdviserDTO;
 import com.adasoft.tis.dto.classCode.ClassCodeResponseDTO;
+import com.adasoft.tis.dto.publication.PublicationResponseDTO;
 import com.adasoft.tis.dto.space.SpaceCompactResponseDTO;
 import com.adasoft.tis.dto.spaceAnswer.SpaceAnswerResponseDTO;
-import com.adasoft.tis.services.AdviserService;
-import com.adasoft.tis.services.ClassCodeService;
-import com.adasoft.tis.services.SpaceAnswerService;
-import com.adasoft.tis.services.SpaceService;
+import com.adasoft.tis.services.*;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +29,7 @@ import static com.adasoft.tis.core.utils.Preconditions.checkUserId;
 public class AdviserRestControllerImpl implements AdviserRestController {
     private AdviserService adviserService;
     private ClassCodeService classCodeService;
+    private PublicationService publicationService;
     private SpaceAnswerService spaceAnswerService;
     private SpaceService spaceService;
 
@@ -115,10 +114,13 @@ public class AdviserRestControllerImpl implements AdviserRestController {
 
     @GetMapping("/{adviserId}/publications/history")
     @Override
-    public ResponseEntity<Collection<SpaceCompactResponseDTO>> getPublicationsHistory(
+    public ResponseEntity<Collection<PublicationResponseDTO>> getPublicationsHistory(
         @RequestAttribute("userId") final Long userId,
         @NotNull @PathVariable("adviserId") final Long adviserId,
         @NotNull @RequestParam("type") final Publication.PublicationType publicationType) {
-        return null;
+        checkUserId(userId, adviserId);
+        Collection<PublicationResponseDTO> publications = publicationService.getHistoryByAdviserId(userId, publicationType);
+
+        return ResponseEntity.ok(publications);
     }
 }

--- a/src/main/java/com/adasoft/tis/repository/PublicationRepository.java
+++ b/src/main/java/com/adasoft/tis/repository/PublicationRepository.java
@@ -9,4 +9,6 @@ public interface PublicationRepository extends TisRepository<Publication, Long> 
     Collection<Publication> getByAdviserId(Long adviserId, Publication.PublicationType type);
 
     Collection<Publication> getByAdviserIdSemester(Long adviserId, Publication.PublicationType type, String semester);
+
+    Collection<Publication> getByAdviserId(Long adviserId, Publication.PublicationType type, boolean includeDeleted);
 }

--- a/src/main/java/com/adasoft/tis/repository/impl/PublicationRepositoryImpl.java
+++ b/src/main/java/com/adasoft/tis/repository/impl/PublicationRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import java.time.LocalDateTime;
 import java.util.Collection;
 
@@ -37,5 +38,16 @@ public class PublicationRepositoryImpl extends AbstractTisRepository<Publication
             .setParameter("semester", semester)
             .setParameter("current", LocalDateTime.now())
             .getResultList();
+    }
+
+    @Override
+    public Collection<Publication> getByAdviserId(Long adviserId, Publication.PublicationType type, boolean includeDeleted) {
+        String jpqlQuery = "SELECT p FROM Publication p WHERE p.createdBy.id = :adviserId and p.type = :type";
+        if (!includeDeleted)
+            jpqlQuery += "and p.deleted = false";
+        TypedQuery<Publication> query = entityManager.createQuery(jpqlQuery, Publication.class)
+            .setParameter("adviserId", adviserId)
+            .setParameter("type", type);
+        return query.getResultList();
     }
 }

--- a/src/main/java/com/adasoft/tis/services/PublicationService.java
+++ b/src/main/java/com/adasoft/tis/services/PublicationService.java
@@ -108,4 +108,19 @@ public class PublicationService {
             .map(publication -> publicationMapper.map(publication, PublicationResponseDTO.class))
             .collect(Collectors.toSet());
     }
+
+    public Collection<PublicationResponseDTO> getHistoryByAdviserId(
+        final Long adviserId,
+        final Publication.PublicationType type) {
+        checkArgument(adviserId != null, "El id de Adviser no puede ser nulo.");
+
+        adviserRepository.findById(adviserId)
+            .orElseThrow(() -> new EntityNotFoundException(Adviser.class, adviserId));
+
+        Collection<Publication> publications = publicationRepository.getByAdviserId(adviserId, type, true);
+
+        return publications.stream()
+            .map(publication -> publicationMapper.map(publication, PublicationResponseDTO.class))
+            .collect(Collectors.toSet());
+    }
 }


### PR DESCRIPTION
Se creó el EndPoint en el controlador de Asesor para obtener el historial de Publicaciones segun su tipo de Publicación.
- EndPoint **/api/advisers/${adviserId}/publications/history**.
- Se consume el servicio para la obtención del historial.
- Se realizó la documentación y las pruebas unitarias correspondientes.