### PR TITLE
EndPoint para obtener las Revisiones publicadas por Estado del Asesor

### DIFF
--- a/src/main/java/com/adasoft/tis/controllers/AdviserRestController.java
+++ b/src/main/java/com/adasoft/tis/controllers/AdviserRestController.java
@@ -8,6 +8,7 @@ import com.adasoft.tis.dto.adviser.UpdateAdviserDTO;
 import com.adasoft.tis.dto.classCode.ClassCodeResponseDTO;
 import com.adasoft.tis.dto.company.CompanyResponseDTO;
 import com.adasoft.tis.dto.publication.PublicationResponseDTO;
+import com.adasoft.tis.dto.review.ReviewResponseDTO;
 import com.adasoft.tis.dto.space.CompanySpacesResponseDTO;
 import com.adasoft.tis.dto.space.SpaceCompactResponseDTO;
 import com.adasoft.tis.dto.spaceAnswer.SemesterSpaceAnswersResponseDTO;
@@ -24,6 +25,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
 import java.util.Collection;
+import java.util.List;
 
 import static com.adasoft.tis.domain.Publication.PublicationType;
 
@@ -453,5 +455,41 @@ public interface AdviserRestController {
         Long userId,
         @Parameter(description = "ID del Asesor") Long id,
         @Parameter(description = "Tipo de publicación") PublicationType publicationType
+    );
+
+    @Operation(summary = "Obtener las revisiones publicadas por estado del adviser", responses = {
+        @ApiResponse(
+            description = "Revisiones publicadas por estado obtenidos satisfactoriamente",
+            responseCode = "200",
+            content = @Content(
+                mediaType = "application/json",
+                array = @ArraySchema(schema = @Schema(implementation = ReviewResponseDTO.class))
+            )
+        ),
+        @ApiResponse(
+            description = "No autorizado, el token es inválido",
+            responseCode = "401",
+            content = @Content(
+                mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            description = "No existe el Asesor",
+            responseCode = "404",
+            content = @Content(
+                mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    }, parameters = @Parameter(
+        in = ParameterIn.HEADER,
+        name = "X-Token",
+        description = "Token del usuario",
+        schema = @Schema(implementation = String.class),
+        required = true
+    ))
+    ResponseEntity<Collection<List<ReviewResponseDTO>>> getReviewsPublishedByStatus(
+        Long userId,
+        @Parameter(description = "ID del Asesor") Long id,
+        @Parameter(description = "ID del Proyecto") Long projectId
     );
 }

--- a/src/main/java/com/adasoft/tis/controllers/impl/AdviserRestControllerImpl.java
+++ b/src/main/java/com/adasoft/tis/controllers/impl/AdviserRestControllerImpl.java
@@ -9,6 +9,7 @@ import com.adasoft.tis.dto.adviser.UpdateAdviserDTO;
 import com.adasoft.tis.dto.classCode.ClassCodeResponseDTO;
 import com.adasoft.tis.dto.company.CompanyResponseDTO;
 import com.adasoft.tis.dto.publication.PublicationResponseDTO;
+import com.adasoft.tis.dto.review.ReviewResponseDTO;
 import com.adasoft.tis.dto.space.CompanySpacesResponseDTO;
 import com.adasoft.tis.dto.space.SpaceCompactResponseDTO;
 import com.adasoft.tis.dto.spaceAnswer.SemesterSpaceAnswersResponseDTO;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Collection;
+import java.util.List;
 
 import static com.adasoft.tis.core.utils.Preconditions.checkUserId;
 
@@ -36,6 +38,7 @@ public class AdviserRestControllerImpl implements AdviserRestController {
     private CompanyService companyService;
     private SemesterService semesterService;
     private PublicationService publicationService;
+    private ReviewService reviewService;
     private SpaceAnswerService spaceAnswerService;
     private SpaceService spaceService;
 
@@ -161,5 +164,17 @@ public class AdviserRestControllerImpl implements AdviserRestController {
         Collection<PublicationResponseDTO> publications = publicationService
             .getHistoryByAdviserId(userId, publicationType);
         return ResponseEntity.ok(publications);
+    }
+
+    @GetMapping("/{adviserId}/reviews/published")
+    @Override
+    public ResponseEntity<Collection<List<ReviewResponseDTO>>> getReviewsPublishedByStatus(
+        @RequestAttribute("userId") final Long userId,
+        @NotNull @PathVariable("adviserId") final Long adviserId,
+        @NotNull @RequestParam("projectId") final Long projectId) {
+        checkUserId(userId, adviserId);
+        Collection<List<ReviewResponseDTO>> response = reviewService
+            .getProjectReviewsPublishedByStatus(userId, projectId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/test/java/com/adasoft/tis/controllers/AdviserRestControllerImplTest.java
+++ b/src/test/java/com/adasoft/tis/controllers/AdviserRestControllerImplTest.java
@@ -10,6 +10,7 @@ import com.adasoft.tis.domain.Space;
 import com.adasoft.tis.dto.classCode.ClassCodeResponseDTO;
 import com.adasoft.tis.dto.company.CompanyResponseDTO;
 import com.adasoft.tis.dto.publication.PublicationResponseDTO;
+import com.adasoft.tis.dto.review.ReviewResponseDTO;
 import com.adasoft.tis.dto.semester.SemesterResponseDTO;
 import com.adasoft.tis.dto.space.CompanySpacesResponseDTO;
 import com.adasoft.tis.dto.space.SpaceCompactResponseDTO;
@@ -25,10 +26,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -56,6 +54,8 @@ class AdviserRestControllerImplTest {
     private CompanySpacesService companySpacesService;
     @MockBean
     private CompanyService companyService;
+    @MockBean
+    private ReviewService reviewService;
     @MockBean
     private SemesterService semesterService;
     @MockBean
@@ -345,5 +345,28 @@ class AdviserRestControllerImplTest {
             .andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(content().json(objectMapper.writeValueAsString(errorResponse)));
+    }
+
+    @Test
+    void getReviewsPublishedByStatusSuccess() throws Exception {
+        when(jwtProvider.decryptUserId(any())).thenReturn(USER_ID);
+        Collection<List<ReviewResponseDTO>> response = new LinkedList<>();
+        when(reviewService.getProjectReviewsPublishedByStatus(any(), any())).thenReturn(response);
+
+        mvc.perform(get(String.format("%s/{adviserId}/reviews/published", BASE_URL), ID)
+                .queryParam("projectId", String.valueOf(PROJECT_ID)).header(X_TOKEN, TOKEN_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(objectMapper.writeValueAsString(response)));
+    }
+
+    @Test
+    void getReviewsPublishedByStatusUnauthorized() throws Exception {
+        when(jwtProvider.decryptUserId(any())).thenReturn(698L);
+
+        mvc.perform(get(String.format("%s/{adviserId}/reviews/published", BASE_URL), ID)
+                .queryParam("projectId", String.valueOf(PROJECT_ID)).header(X_TOKEN, TOKEN_VALUE))
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
Se creó el EndPoint para obtener las Revisiones que fueron publicadas por el Asesor.
**ENDPOINT:** /api/{adviserId}/reviews/published
- Se consumió el Servicio de ReviewService.
- Se realizó su documentación del EndPoint.
- Se realizó las Pruebas Unitarias necesarias.