### PR TITLE
EndPoint para obtener las Revisiones de una GE en su versión extendida

### DIFF
--- a/src/main/java/com/adasoft/tis/controllers/CompanyRestController.java
+++ b/src/main/java/com/adasoft/tis/controllers/CompanyRestController.java
@@ -285,4 +285,38 @@ public interface CompanyRestController {
         @Parameter(description = "Tipo de space") Space.SpaceType spaceType
     );
 
+    @Operation(summary = "Obtener las revisiones en versión extendida por GE", responses = {
+        @ApiResponse(
+            description = "Revisiones obtenidos satisfactoriamente",
+            responseCode = "200",
+            content = @Content(
+                mediaType = "application/json",
+                array = @ArraySchema(schema = @Schema(implementation = ReviewResponseDTO.class))
+            )
+        ),
+        @ApiResponse(
+            description = "No autorizado, el token es inválido",
+            responseCode = "401",
+            content = @Content(
+                mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            description = "No existe la GE",
+            responseCode = "404",
+            content = @Content(
+                mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    }, parameters = @Parameter(
+        in = ParameterIn.HEADER,
+        name = "X-Token",
+        description = "Token del usuario",
+        schema = @Schema(implementation = String.class),
+        required = true
+    ))
+    ResponseEntity<Collection<ReviewResponseDTO>> getExtendedReviews(
+        Long userId,
+        @Parameter(description = "ID de la GE") Long id
+    );
 }

--- a/src/main/java/com/adasoft/tis/controllers/impl/CompanyRestControllerImpl.java
+++ b/src/main/java/com/adasoft/tis/controllers/impl/CompanyRestControllerImpl.java
@@ -110,4 +110,14 @@ public class CompanyRestControllerImpl implements CompanyRestController {
         Collection<SpaceCompactResponseDTO> responses = spaceService.getCompanySpaces(companyId, spaceType);
         return ResponseEntity.ok(responses);
     }
+
+    @GetMapping("/{companyId}/extended-reviews")
+    @Override
+    public ResponseEntity<Collection<ReviewResponseDTO>> getExtendedReviews(
+        @RequestAttribute("userId") final Long userId,
+        @NotNull @PathVariable("companyId") final Long companyId) {
+        checkUserId(userId, companyId);
+        Collection<ReviewResponseDTO> response = reviewService.getCompanyReviewsExt(companyId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/test/java/com/adasoft/tis/controllers/CompanyRestControllerImplTest.java
+++ b/src/test/java/com/adasoft/tis/controllers/CompanyRestControllerImplTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedList;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -243,5 +244,28 @@ class CompanyRestControllerImplTest {
         mvc.perform(get(String.format("%s/{companyId}/spaces", BASE_URL), ID)
                 .queryParam("spaceType", "ALL").header(X_TOKEN, TOKEN_VALUE))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getExtendedReviewsSuccess() throws Exception {
+        when(jwtProvider.decryptUserId(any())).thenReturn(USER_ID);
+        Collection<ReviewResponseDTO> response = new LinkedList<>();
+        when(reviewService.getCompanyReviewsExt(any())).thenReturn(response);
+
+        mvc.perform(get(String.format("%s/{companyId}/extended-reviews", BASE_URL), ID)
+                .header(X_TOKEN, TOKEN_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(objectMapper.writeValueAsString(response)));
+    }
+
+    @Test
+    void getExtendedReviewsUnauthorized() throws Exception {
+        when(jwtProvider.decryptUserId(any())).thenReturn(67L);
+
+        mvc.perform(get(String.format("%s/{companyId}/extended-reviews", BASE_URL), ID)
+                .header(X_TOKEN, TOKEN_VALUE))
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
Se creó el EndPoint para obtener las Revisiones de una GE con la versión extendida de la Revisión.
**ENDPOINT:** /api/companies/{companyId}/extended-reviews
- Se realizó la documentación del EndPoint.
- Se consume el Servicio de ReviewService.
- Se realizaron las Pruebas Unitarias necesarias.